### PR TITLE
LVM configuration support for LXC

### DIFF
--- a/lib/puppet/provider/virt/lxc.rb
+++ b/lib/puppet/provider/virt/lxc.rb
@@ -13,12 +13,27 @@ Puppet::Type.type(:virt).provide :lxc do
     has_features :cloneable
     has_features :backingstore
     has_features :initial_config
+    has_features :manages_lvm
 
     def install
       args = ['-n', @resource[:name]]
       args.push('-t', @resource[:os_template])
       if !@resource[:backingstore].nil?
          args.push('-B', @resource[:backingstore])
+      end
+      if @resource[:backingstore].to_s == 'lvm'
+        if !@resource[:vgname].nil?
+          args.push('--vgname', @resource[:vgname])
+        end
+        if !@resource[:lvname].nil?
+          args.push('--lvname', @resource[:lvname])
+        end
+        if !@resource[:fssize].nil?
+          args.push('--fssize', @resource[:fssize])
+        end
+        if !@resource[:fstype].nil?
+          args.push('--fstype', @resource[:fstype])
+        end
       end
       if !@resource[:configfile].nil?
          args.push('-f', @resource[:configfile])
@@ -33,6 +48,15 @@ Puppet::Type.type(:virt).provide :lxc do
     def clone
       args = ['-o', @resource[:clone]]
       args.push('-n', @resource[:name])
+
+      if @resource[:backingstore].to_s == 'lvm'
+        if !@resource[:vgname].nil?
+          args.push('-v', @resource[:vgname])
+        end
+        if !@resource[:fssize].nil?
+          args.push('-L', @resource[:fssize])
+        end
+      end
       if @resource[:snapshot]
          args.push('-s')
       end

--- a/lib/puppet/type/virt.rb
+++ b/lib/puppet/type/virt.rb
@@ -28,6 +28,9 @@ Puppet::Type.newtype(:virt) do
     feature :manages_users,
       "Manages guest's users."
 
+    feature :manages_lvm,
+      "Manages LVM."
+
     feature :iptables,
       "Load iptables modules."
 
@@ -402,6 +405,24 @@ Image files must end with `*.img`, `*.qcow` or `*.qcow2`"
 
     newproperty(:diskspace, :required_features => :disk_quota) do
       desc "Sets soft and hard disk quotas, in blocks. First parameter is soft quota, second is hard quota. One block is currently equal to 1Kb. Also suffixes G, M, K can be specified."
+    end
+
+    # LXC/LVM specific paramters
+
+    newparam(:vgname, :required_features => :manages_lvm) do
+      desc "Use specified Volume Group (defaults to lxc) in LXC."
+    end
+
+    newparam(:lvname, :required_features => :manages_lvm) do
+      desc "Use specified name for Logical Volume (defaults to hostname) in LXC."
+    end
+
+    newparam(:fssize, :required_features => :manages_lvm) do
+      desc "Specify LV size (defaults to 1G) for LXC."
+    end
+
+    newparam(:fstype, :required_features => :manages_lvm) do
+      desc "Specify LV filesystem type  (defaults to ext4) for LXC."
     end
 
     # Device access management


### PR DESCRIPTION
I added required parameters to use LVM with a non-default VG or LV name. It's not the most elegant solution, but there's no alternative AFAICS.
