### PR TITLE
Fix initial configuration file validation 

### DIFF
--- a/lib/puppet/type/virt.rb
+++ b/lib/puppet/type/virt.rb
@@ -195,6 +195,10 @@ Puppet::Type.newtype(:virt) do
       end
     end
 
+    autorequire(:file) do
+      self[:configfile] if self[:configfile]
+    end
+
     newproperty(:ipaddr, :array_matching => :all, :required_features => :ip) do
       desc "IP address(es) of the VE."
 


### PR DESCRIPTION
Previous validation of the `configfile` parameter made it impossible to use a file managed by puppet. This is because the validation happens during compilation time when the file does not yet exist.

I've changed the validation to check for an absolute pathname and to autorequire the corresponding file resource in the catalog. Unfortunately `autorequire` won't fail if the resource does not exist.
