### PR TITLE
Typo in conditional.

### DIFF
--- a/lib/puppet/provider/virt/libvirt.rb
+++ b/lib/puppet/provider/virt/libvirt.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:virt).provide(:libvirt) do
     parameters = ""
     parameters = resource[:virt_path] if resource[:virt_path]
     parameters.concat("," + resource[:disk_size]) if resource[:disk_size]
-    parameters.empty? [] : ["--disk", parameters]
+    parameters.empty? ? [] : ["--disk", parameters]
   end
 
   # Additional boot arguments


### PR DESCRIPTION
  The conditional used to identify is the --disk parameter needs to be
  used had a typo in it.  This commit fixes it by adding a ?.

  This typo made the virt type un-usable because it prevented
  compilation.
