### PR TITLE
Make check for existing container more robust

### DIFF
--- a/lib/puppet/provider/virt/openvz.rb
+++ b/lib/puppet/provider/virt/openvz.rb
@@ -137,8 +137,9 @@ Puppet::Type.type(:virt).provide(:openvz) do
   end
 
   def exists?
-    stat = vzctl('status', ctid).split(" ")
-    !(stat.nil? || stat[2] == "deleted")
+    cmdoutput = vzctl('status', ctid)
+    stat = cmdoutput.split(" ")
+    !(stat.nil? || stat[2] == "deleted" || cmdoutput.match(/deleted/))
   end
 
   # OpenVZ guests status: exist, deleted, mouted, umounted, running, down


### PR DESCRIPTION
On some systems vzctl status returns something like

stat(/var/lib/vz/root/101): No suchv file or directory CTID 101 deleted unmounted down
