### PR TITLE
Ensure future parser compatibility (>3.5.1)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,25 +7,25 @@ class virt::params {
       $confdir = '/etc/vz/conf/'
       $vedir = '/var/lib/vz/' # You can update here with your custom value
       $packages = $operatingsystem ? {
-        Debian => [ "linux-image-${kernelmajversion}-openvz-686", 'vzctl', 'vzquota' ],
-        Ubuntu => [ "linux-image-${kernelmajversion}-openvz-686", 'vzctl', 'vzquota' ],
-        Fedora => [ 'ovzkernel', 'vzctl', 'vzquota' ],
+        'Debian' => [ "linux-image-${kernelmajversion}-openvz-686", 'vzctl', 'vzquota' ],
+        'Ubuntu' => [ "linux-image-${kernelmajversion}-openvz-686", 'vzctl', 'vzquota' ],
+        'Fedora' => [ 'ovzkernel', 'vzctl', 'vzquota' ],
       }
     }
     /^physical|^kvm/: {
       $servicename = 'libvirtd'
       $packages = $operatingsystem ? {
-        Debian => [ 'kvm', 'libvirt0', 'libvirt-bin', 'qemu', 'virtinst', 'libvirt-ruby' ],
-        Ubuntu => [ 'ubuntu-virt-server', 'python-vm-builder', 'kvm', 'qemu', 'qemu-kvm', 'libvirt-ruby' ],
-        Fedora => [ 'kvm', 'qemu', 'libvirt', 'python-virtinst', 'ruby-libvirt' ],
+        'Debian' => [ 'kvm', 'libvirt0', 'libvirt-bin', 'qemu', 'virtinst', 'libvirt-ruby' ],
+        'Ubuntu' => [ 'ubuntu-virt-server', 'python-vm-builder', 'kvm', 'qemu', 'qemu-kvm', 'libvirt-ruby' ],
+        'Fedora' => [ 'kvm', 'qemu', 'libvirt', 'python-virtinst', 'ruby-libvirt' ],
       }
     }
     /^xen/: {
       $servicename = 'libvirtd'
       $packages = $operatingsystem ? {
-        Debian => [ 'linux-image-xen-686', 'xen-hypervisor', 'xen-tools', 'xen-utils' ],
-        Ubuntu => [ 'python-vm-builder', 'ubuntu-xen-server', 'libvirt-ruby' ],
-        Fedora => [ 'kernel-xen', 'xen', 'ruby-libvirt' ],
+        'Debian' => [ 'linux-image-xen-686', 'xen-hypervisor', 'xen-tools', 'xen-utils' ],
+        'Ubuntu' => [ 'python-vm-builder', 'ubuntu-xen-server', 'libvirt-ruby' ],
+        'Fedora' => [ 'kernel-xen', 'xen', 'ruby-libvirt' ],
       }
     }
     default: {


### PR DESCRIPTION
Since Puppet 3.5.1 the future parser no longer matches upper case words in a selector statement as they are treated as a custom resource type.

See https://tickets.puppetlabs.com/browse/PUP-2800?focusedCommentId=76016&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-76016 for details.
