### PR TITLE
Fix manifest errors related to Debian.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,14 +10,10 @@ class virt {
     subscribe => Package[$virt::params::packages],
   }
 
-  service { $virt::params::service:
+  service { $virt::params::servicename:
     ensure => running,
     enable => true,
-  }
-
-  service { $servicename:
-    ensure => 'running',
-    enable => 'true',
+    subscribe => Package[$virt::params::packages],
   }
 
   case $virtual {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,10 @@ class virt::params {
       }
     }
     /^physical|^kvm/: {
-      $servicename = 'libvirtd'
+      $servicename = $operatingsystem ? {
+        'Debian' => 'libvirt-bin',
+        default  => 'libvirtd',
+      }
       $packages = $operatingsystem ? {
         'Debian' => [ 'kvm', 'libvirt0', 'libvirt-bin', 'qemu', 'virtinst', 'libvirt-ruby' ],
         'Ubuntu' => [ 'ubuntu-virt-server', 'python-vm-builder', 'kvm', 'qemu', 'qemu-kvm', 'libvirt-ruby' ],
@@ -21,16 +24,15 @@ class virt::params {
       }
     }
     /^xen/: {
-      $servicename = 'libvirtd'
+      $servicename = $operatingsystem ? {
+        'Debian' => 'libvirt-bin',
+        default  => 'libvirtd',
+      }
       $packages = $operatingsystem ? {
         'Debian' => [ 'linux-image-xen-686', 'xen-hypervisor', 'xen-tools', 'xen-utils' ],
         'Ubuntu' => [ 'python-vm-builder', 'ubuntu-xen-server', 'libvirt-ruby' ],
         'Fedora' => [ 'kernel-xen', 'xen', 'ruby-libvirt' ],
       }
     }
-    default: {
-      $servicename = 'libvirtd'
-    }
   }
-
 }


### PR DESCRIPTION
  This commit adds conditionals for servicename to provide the proper
  name of libvirt-bin to debian platforms.

  Without this the module and does not compile on any debian going back
  to squeeze.