### PR TITLE
add CentOS (and matching packages) possibility for qemu-kvm

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class virt::params {
         'Debian' => [ 'kvm', 'libvirt0', 'libvirt-bin', 'qemu', 'virtinst', 'libvirt-ruby' ],
         'Ubuntu' => [ 'ubuntu-virt-server', 'python-vm-builder', 'kvm', 'qemu', 'qemu-kvm', 'libvirt-ruby' ],
         'Fedora' => [ 'kvm', 'qemu', 'libvirt', 'python-virtinst', 'ruby-libvirt' ],
+        'CentOS' => [ 'qemu-kvm', 'libvirt', 'python-virtinst', 'ruby-libvirt' ],
       }
     }
     /^xen/: {


### PR DESCRIPTION
I'm using your module on a CentOS machine. I did not try openVZ nor Xen, so I don't know about the packages name, but this works for CentOS 6.5