### PR TITLE
Add openSUSE / SLES variables in the openvz provider

### DIFF
--- a/lib/puppet/provider/virt/openvz.rb
+++ b/lib/puppet/provider/virt/openvz.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:virt).provide(:openvz) do
   when "Ubuntu", "Debian"
     @@vzcache = "/var/lib/vz/template/cache/"
     @@vzconf = "/etc/vz/conf/"
-  when "CentOS", "Fedora"
+  when "CentOS", "Fedora", "OpenSuSE", "SLES"
     @@vzcache = "/vz/template/cache/"
     @@vzconf = "/etc/vz/conf/"
   else


### PR DESCRIPTION
If they are missing, the whole module is not working, even when we're not using
the openvz provider at all