### PR TITLE
Quote file mode parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class virt {
   File {
     owner => 'root',
     group => 'root',
-    mode => 0644,
+    mode => '0644',
     subscribe => Package[$virt::params::packages],
   }
 

--- a/manifests/ve.pp
+++ b/manifests/ve.pp
@@ -146,7 +146,7 @@ define virt::ve (
     ensure => directory,
     owner => 'root',
     group => 'root',
-    mode => 0755,
+    mode => '0755',
   }
 
   lvm::volume { $name:


### PR DESCRIPTION
Puppet 4 requires that the values for the `mode` parameter on `file`
resources be strings, not octal integers. This quotes two instances of
bareword octal numbers.